### PR TITLE
Removed the extra whitespace characters from 3 lines that are supposed to be blank in rsync.bat

### DIFF
--- a/packages/cwrsync/tools/rsync.bat
+++ b/packages/cwrsync/tools/rsync.bat
@@ -1,10 +1,10 @@
 @ECHO OFF
- 
+
 SETLOCAL
- 
+
 SET RSYNC_HOME=%chocolateyInstall%\lib\cwrsync\tools\cwrsync\bin
 SET PATH=%RSYNC_HOME%;%PATH%
 
 IF NOT DEFINED HOME SET HOME=%USERPROFILE%
- 
+
 rsync %*


### PR DESCRIPTION
Removed the extra whitespace characters from 3 lines that are supposed to be blank in rsync.bat since they were causing errors when trying to use this for vagrant.

When I run rsync, I got the following error reported three times:

'┬á' is not recognized as an internal or external command,
operable program or batch file.

To fix, I edited the file at chocolatey\lib\cwrsync\tools\rsync.bat and removed the extra single character on those 3 lines that should have been empty lines.

Hoping you'll accept this pull request so that everyone else can enjoy this.